### PR TITLE
Fix tokens defined by reference to environment variables

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
     "node": true
   },
   "rules": {
+    "no-process-env": 0,
     "no-var": 0,
     "prefer-template": 0,
     "prefer-arrow-callback": 0

--- a/index.js
+++ b/index.js
@@ -17,6 +17,12 @@ module.exports = function (registryUrl, opts) {
 
     match = npmrc[regUrl + tokenKey] || npmrc[urlAlt + tokenKey]
 
+    if (match) {
+      match = match.replace(/^\$(\{)?([^}]*)\}?$/, function ($0, $1, $2, index, input) {
+        return process.env[$2]
+      })
+    }
+
     if (!options.recursive) {
       return match
     }

--- a/test.js
+++ b/test.js
@@ -60,6 +60,40 @@ describe('registry-auth-token', function () {
     })
   })
 
+  it('should return auth token defined by reference to an environment variable (with curly braces)', function (done) {
+    var environmentVariable = '__REGISTRY_AUTH_TOKEN_NPM_TOKEN__'
+    var content = [
+      'registry=http://registry.foobar.cc/',
+      '//registry.foobar.cc/:_authToken=${' + environmentVariable + '}', ''
+    ].join('\n')
+    process.env[environmentVariable] = 'foobar'
+
+    fs.writeFile(npmRcPath, content, function (err) {
+      var getAuthToken = requireUncached('./index')
+      assert(!err, err)
+      assert.equal(getAuthToken(), 'foobar')
+      delete process.env[environmentVariable]
+      done()
+    })
+  })
+
+  it('should return auth token defined by reference to an environment variable (without curly braces)', function (done) {
+    var environmentVariable = '__REGISTRY_AUTH_TOKEN_NPM_TOKEN__'
+    var content = [
+      'registry=http://registry.foobar.cc/',
+      '//registry.foobar.cc/:_authToken=$' + environmentVariable, ''
+    ].join('\n')
+    process.env[environmentVariable] = 'foobar'
+
+    fs.writeFile(npmRcPath, content, function (err) {
+      var getAuthToken = requireUncached('./index')
+      assert(!err, err)
+      assert.equal(getAuthToken(), 'foobar')
+      delete process.env[environmentVariable]
+      done()
+    })
+  })
+
   it('should try with and without a slash at the end of registry url', function (done) {
     var content = [
       'registry=http://registry.foobar.eu',


### PR DESCRIPTION
Users of private npm modules (especialy in conjunction with npm organizations) commonly have package-local `.npmrc` files that use an environment variable as a placeholder for the auth token. The npm cli dereferences these placeholders automatically. It would be preferable if this module matched that behavior.

Currently, this lack of parity impacts the wombat tool. npm/wombat-cli#11
