### PR TITLE
fix recursion bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var url = require('url')
+var path = require('path')
 var tokenKey = ':_authToken'
 var userKey = ':username'
 var passwordKey = ':_password'
@@ -23,7 +24,7 @@ module.exports = function getRegistryAuthInfo(registryUrl, opts) {
       return undefined
     }
 
-    parsed.pathname = url.resolve(pathname, '..') || '/'
+    parsed.pathname = path.dirname(pathname, '..') || '/'
   }
 
   return undefined

--- a/test/auth-token.test.js
+++ b/test/auth-token.test.js
@@ -139,12 +139,16 @@ describe('auth-token', function () {
       var opts = {recursive: true}
       var content = [
         '//registry.blah.com/foo:_authToken=whatev',
+        '//registry.blah.org/foo/bar:_authToken=recurseExactlyOneLevel',
+        '//registry.blah.edu/foo/bar/baz:_authToken=recurseNoLevel',
         '//registry.blah.eu:_authToken=yep', ''
       ].join('\n')
 
       fs.writeFile(npmRcPath, content, function (err) {
         var getAuthToken = requireUncached('../index')
         assert(!err, err)
+        assert.deepEqual(getAuthToken('https://registry.blah.edu/foo/bar/baz', opts), {token: 'recurseNoLevel', type: 'Bearer'})
+        assert.deepEqual(getAuthToken('https://registry.blah.org/foo/bar/baz', opts), {token: 'recurseExactlyOneLevel', type: 'Bearer'})
         assert.deepEqual(getAuthToken('https://registry.blah.com/foo/bar/baz', opts), {token: 'whatev', type: 'Bearer'})
         assert.deepEqual(getAuthToken('http://registry.blah.eu/what/ever', opts), {token: 'yep', type: 'Bearer'})
         assert.equal(getAuthToken('//some.registry', opts), undef)


### PR DESCRIPTION
The recursion is actually flawed.

```
getAuthToken('https://example.org/api/npm/npm/react-dom', {recursive: true})
// checks https://example.org/api/npm/npm/react-dom
// not checking https://example.org/api/npm/npm
// checks https://example.org/api/npm
// checks https://example.org/api
// checks https://example.org
```

The behaviour of url.resolve with missing trailing slashes causes this:

```
url.resolve('https://example.org/api/npm/npm/react-dom', '..')
// returns 'https://example.org/api/npm/'

url.resolve('https://example.org/api/npm/npm/react-dom/', '..')
// returns 'https://example.org/api/npm/npm/'

```

`path.dirname` actually solves this really nicely.
