### PR TITLE
fix: avoid infinite loop on invalid URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ module.exports = function getRegistryAuthInfo(registryUrl, opts) {
   var parsed = url.parse(checkUrl, false, true)
   var pathname
 
-  while (pathname !== '/') {
+  while (pathname !== '/' && parsed.pathname !== pathname) {
     pathname = parsed.pathname || '/'
 
     var regUrl = '//' + parsed.host + pathname.replace(/\/$/, '')

--- a/test/auth-token.test.js
+++ b/test/auth-token.test.js
@@ -147,6 +147,7 @@ describe('auth-token', function () {
         assert.deepEqual(getAuthToken('https://registry.blah.org/foo/bar/baz', opts), {token: 'recurseExactlyOneLevel', type: 'Bearer'})
         assert.deepEqual(getAuthToken('https://registry.blah.com/foo/bar/baz', opts), {token: 'whatev', type: 'Bearer'})
         assert.deepEqual(getAuthToken('http://registry.blah.eu/what/ever', opts), {token: 'yep', type: 'Bearer'})
+        assert.deepEqual(getAuthToken('http://registry.blah.eu//what/ever', opts), undefined, 'does not hang')
         assert.equal(getAuthToken('//some.registry', opts), undef)
         done()
       })


### PR DESCRIPTION
Maybe this is not the best solution to the problem but it solves an infinite loop issue (it was causing an issue at pnpm and it was very hard to find)

An alternative solution might be to throw an error if an invalid URL is passed in.

Also it might be better to use recursion instead of the loop. At least it would throw a stackoverflow error... 