### PR TITLE
feat: support legacy auth token config key

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ module.exports = function () {
   options = options || {}
   options.npmrc = options.npmrc || require('rc')('npm', {registry: 'https://registry.npmjs.org/'})
   checkUrl = checkUrl || options.npmrc.registry
-  return getRegistryAuthInfo(checkUrl, options)
+  return getRegistryAuthInfo(checkUrl, options) || getLegacyAuthInfo(options.npmrc)
 }
 
 function getRegistryAuthInfo(checkUrl, options) {
@@ -48,6 +48,13 @@ function getRegistryAuthInfo(checkUrl, options) {
     parsed.pathname = url.resolve(normalizePath(pathname), '..') || '/'
   }
 
+  return undefined
+}
+
+function getLegacyAuthInfo(npmrc) {
+  if (npmrc._auth) {
+    return getBearerToken(npmrc._auth)
+  }
   return undefined
 }
 

--- a/test/auth-token.test.js
+++ b/test/auth-token.test.js
@@ -52,6 +52,20 @@ describe('auth-token', function () {
       })
     })
 
+    it('should return auth token if it is defined in the legacy way via the `_auth` key', function (done) {
+      var content = [
+        '_auth=foobar',
+        'registry=http://registry.foobar.eu/',
+      ].join('\n')
+
+      fs.writeFile(npmRcPath, content, function (err) {
+        var getAuthToken = requireUncached('../index')
+        assert(!err, err)
+        assert.deepEqual(getAuthToken(), {token: 'foobar', type: 'Bearer'})
+        done()
+      })
+    })
+
     it('should use npmrc passed in', function (done) {
       var content = [
         'registry=http://registry.foobar.eu/',


### PR DESCRIPTION
If cannot find auth token, try to get it from the legacy `_auth` config key.

This should solve two issues at pnpm:
https://github.com/pnpm/pnpm/issues/708
https://github.com/pnpm/pnpm/issues/618