### PR TITLE
WIP: Return basic token if _auth is base64 encoded

### DIFF
--- a/test/auth-token.test.js
+++ b/test/auth-token.test.js
@@ -264,6 +264,25 @@ describe('auth-token', function () {
       })
     })
 
+    it('should return basic token if _auth is base64 encoded', function (done) {
+      var content = [
+        'registry=http://registry.foobar.eu/',
+        '//registry.foobar.eu/:_auth=' + encodeBase64('foobar:foobar')
+      ].join('\n')
+
+      fs.writeFile(npmRcPath, content, function (err) {
+        var getAuthToken = requireUncached('../index')
+        assert(!err, err)
+        var token = getAuthToken()
+        assert.deepEqual(token, {
+          token: 'Zm9vYmFyOmZvb2Jhcg==',
+          type: 'Basic'
+        })
+        assert.equal(decodeBase64(token.token), 'foobar:foobar')
+        done()
+      })
+    })    
+    
     it('should return basic token if registry url has port specified', function (done) {
       var content = [
         'registry=http://localhost:8770/',


### PR DESCRIPTION
I wanted to raise this as a WIP PR with test first to see if you agree with this use case. I found that Artifactory needs a basic token when `//host:_auth=${encodeBase64(username + ':' + password)}` https://jfrog.com/knowledge-base/how-to-authenticate-against-artifactory-with-a-http-rest-client/