### PR TITLE
rc to 1.2.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/rexxars/registry-auth-token#readme",
   "dependencies": {
-    "rc": "^1.1.6",
+    "rc": "^1.2.8",
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Purpose is to fix the deep-extend vulnerability

> The utilities function in all versions <= 0.5.0 of the deep-extend node module can be tricked into modifying the prototype of Object when the attacker can control part of the structure passed to this function. This can let an attacker add or modify existing properties that will exist on all objects.