### PR TITLE
Support for legacy auth token on the registry url

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var decodeBase64 = base64.decodeBase64
 var encodeBase64 = base64.encodeBase64
 
 var tokenKey = ':_authToken'
+var legacyTokenKey = ':_auth'
 var userKey = ':username'
 var passwordKey = ':_password'
 
@@ -80,6 +81,11 @@ function getAuthInfoForUrl (regUrl, npmrc) {
     return basicAuth
   }
 
+  var basicAuthWithToken = getLegacyAuthToken(npmrc[regUrl + legacyTokenKey] || npmrc[regUrl + '/' + legacyTokenKey])
+  if (basicAuthWithToken) {
+    return basicAuthWithToken
+  }
+
   return undefined
 }
 
@@ -120,4 +126,16 @@ function getTokenForUsernameAndPassword (username, password) {
     password: pass,
     username: username
   }
+}
+
+
+function getLegacyAuthToken (tok) {
+  if (!tok) {
+    return undefined
+  }
+
+  // check if legacy auth token is set as environment variable
+  var token = replaceEnvironmentVariable(tok)
+
+  return { token: token, type: 'Basic' }
 }

--- a/index.js
+++ b/index.js
@@ -128,7 +128,6 @@ function getTokenForUsernameAndPassword (username, password) {
   }
 }
 
-
 function getLegacyAuthToken (tok) {
   if (!tok) {
     return undefined

--- a/test/auth-token.test.js
+++ b/test/auth-token.test.js
@@ -300,6 +300,25 @@ describe('auth-token', function () {
       })
     })
 
+    it('should return basic token if _auth is base64 encoded', function (done) {
+      var content = [
+        'registry=http://registry.foobar.eu/',
+        '//registry.foobar.eu/:_auth=' + encodeBase64('foobar:foobar')
+      ].join('\n')
+
+      fs.writeFile(npmRcPath, content, function (err) {
+        var getAuthToken = requireUncached('../index')
+        assert(!err, err)
+        var token = getAuthToken()
+        assert.deepEqual(token, {
+          token: 'Zm9vYmFyOmZvb2Jhcg==',
+          type: 'Basic'
+        })
+        assert.equal(decodeBase64(token.token), 'foobar:foobar')
+        done()
+      })
+    })  
+
     it('should return basic token if registry url has port specified', function (done) {
       var content = [
         'registry=http://localhost:8770/',

--- a/test/auth-token.test.js
+++ b/test/auth-token.test.js
@@ -317,7 +317,7 @@ describe('auth-token', function () {
         assert.equal(decodeBase64(token.token), 'foobar:foobar')
         done()
       })
-    })  
+    })
 
     it('should return basic token if registry url has port specified', function (done) {
       var content = [

--- a/test/auth-token.test.js
+++ b/test/auth-token.test.js
@@ -310,11 +310,11 @@ describe('auth-token', function () {
         var getAuthToken = requireUncached('../index')
         assert(!err, err)
         var token = getAuthToken()
-        assert.deepEqual(token, {
+        assert.deepStrictEqual(token, {
           token: 'Zm9vYmFyOmZvb2Jhcg==',
           type: 'Basic'
         })
-        assert.equal(decodeBase64(token.token), 'foobar:foobar')
+        assert.strictEqual(decodeBase64(token.token), 'foobar:foobar')
         done()
       })
     })


### PR DESCRIPTION
This PR implements the functionality mentioned in PR https://github.com/rexxars/registry-auth-token/pull/20:

> I wanted to raise this as a WIP PR with test first to see if you agree with this use case. I found that Artifactory needs a basic token when //host:_auth=${encodeBase64(username + ':' + password)} https://jfrog.com/knowledge-base/how-to-authenticate-against-artifactory-with-a-http-rest-client/