### PR TITLE
remove safe-buffer

### DIFF
--- a/base64.js
+++ b/base64.js
@@ -1,11 +1,9 @@
-const safeBuffer = require('safe-buffer').Buffer
-
 function decodeBase64 (base64) {
-  return safeBuffer.from(base64, 'base64').toString('utf8')
+  return Buffer.from(base64, 'base64').toString('utf8')
 }
 
 function encodeBase64 (string) {
-  return safeBuffer.from(string, 'utf8').toString('base64')
+  return Buffer.from(string, 'utf8').toString('base64')
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2145,11 +2145,6 @@
         "symbol-observable": "1.0.1"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
   },
   "homepage": "https://github.com/rexxars/registry-auth-token#readme",
   "dependencies": {
-    "rc": "^1.2.8",
-    "safe-buffer": "^5.0.1"
+    "rc": "^1.2.8"
   },
   "devDependencies": {
     "istanbul": "^0.4.2",


### PR DESCRIPTION
Node >= 6 includes Buffer.from so this dependency became unneccessary.