### PR TITLE
fix: make all arguments optional in type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,64 +1,67 @@
 declare namespace registryAuthToken {
+  /**
+   * The options for passing into `registry-auth-token`
+   */
+  interface AuthOptions {
     /**
-     * The options for passing into `registry-auth-token`
+     * Whether or not url's path parts are recursively trimmed from the registry
+     * url when searching for tokens
      */
-    interface AuthOptions {
-        /**
-         * Whether or not url's path parts are recursively trimmed from the registry
-         * url when searching for tokens
-         */
-        recursive?: boolean | undefined;
-        /**
-         * An npmrc configuration object used when searching for tokens. If no object is provided,
-         * the `.npmrc` file at the base of the project is used.
-         */
-        npmrc?: {
-            /**
-             * A registry url used for matching
-             */
-            registry?: string | undefined;
-            /**
-             * Registry url's with token information
-             */
-            [registryUrls: string]: string | undefined;
-        } | undefined;
-    }
+    recursive?: boolean | undefined;
     /**
-     * The generated authentication information
+     * An npmrc configuration object used when searching for tokens. If no object is provided,
+     * the `.npmrc` file at the base of the project is used.
      */
-    interface NpmCredentials {
-        /**
-         * The token representing the users credentials
-         */
-        token: string;
-        /**
-         * The type of token
-         */
-        type: 'Basic' | 'Bearer';
-        /**
-         * The username used in `Basic`
-         */
-        username?: string | undefined;
-        /**
-         * The password used in `Basic`
-         */
-        password?: string | undefined;
-    }
+    npmrc?:
+      | {
+          /**
+           * A registry url used for matching
+           */
+          registry?: string | undefined;
+          /**
+           * Registry url's with token information
+           */
+          [registryUrls: string]: string | undefined;
+        }
+      | undefined;
+  }
+  /**
+   * The generated authentication information
+   */
+  interface NpmCredentials {
+    /**
+     * The token representing the users credentials
+     */
+    token: string;
+    /**
+     * The type of token
+     */
+    type: 'Basic' | 'Bearer';
+    /**
+     * The username used in `Basic`
+     */
+    username?: string | undefined;
+    /**
+     * The password used in `Basic`
+     */
+    password?: string | undefined;
+  }
 }
 
 /**
  * Retrieves the auth token to use for a given registry URL
  *
- * @param registryUrl - Either the registry url used for matching, or a configuration
- * object describing the contents of the .npmrc file
+ * @param [registryUrl] - Either the registry url used for matching, or a configuration
+ * object describing the contents of the .npmrc file. Uses default `registry` set in
+ * `.npmrc` when argument is omitted.
  * @param [options] - a configuration object describing the
  * contents of the .npmrc file.  If an `npmrc` config object was passed in as the
  * first parameter, this parameter is ignored.
  * @returns The `NpmCredentials` object or undefined if no match found.
  */
 declare function registryAuthToken(
-    registryUrl: string | registryAuthToken.AuthOptions,
-    options?: registryAuthToken.AuthOptions,
+  registryUrl?: string | registryAuthToken.AuthOptions,
+  options?: registryAuthToken.AuthOptions
 ): registryAuthToken.NpmCredentials | undefined;
 
 export = registryAuthToken;

--- a/registry-url.d.ts
+++ b/registry-url.d.ts
@@ -1,12 +1,15 @@
 import { AuthOptions } from './';
 
 /**
- * Get the registry URL for a given npm scope
+ * Get the registry URL for a given npm scope. Falls back to global registry is scope is not defined.
  *
- * @param scope - npm scope to resolve URL for
+ * @param [scope] - npm scope to resolve URL for. Falls back to global registry if not defined.
  * @param [npmrc] - Optional object of npmrc properties to use instead of looking up the users local npmrc file
  * @returns The resolved registry URL, falling back to the global npm registry
  */
-declare function registryUrl(scope: string, npmrc?: Pick<AuthOptions, 'npmrc'>): string;
+declare function registryUrl(
+  scope?: string,
+  npmrc?: Pick<AuthOptions, 'npmrc'>
+): string;
 
 export = registryUrl;

--- a/registry-url.d.ts
+++ b/registry-url.d.ts
@@ -1,7 +1,7 @@
 import { AuthOptions } from './';
 
 /**
- * Get the registry URL for a given npm scope. Falls back to global registry is scope is not defined.
+ * Get the registry URL for a given npm scope. Falls back to global registry if scope is not defined.
  *
  * @param [scope] - npm scope to resolve URL for. Falls back to global registry if not defined.
  * @param [npmrc] - Optional object of npmrc properties to use instead of looking up the users local npmrc file


### PR DESCRIPTION
I am using `getRegistryUrl` and `getRegistryAuthToken` with no arguments. The type definitions for these functions say the first arguments are required but I'm thinking this is a mistake.

Both functions have fallbacks for when there are no arguments, and the examples in the README show both of them used without arguments.

It's not a big deal to `// @ts-ignore` these two lines, but if you're taking contributions it might be nice to be able to remove those two ignores.