### PR TITLE
chore: use public repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/rexxars/registry-auth-token.git"
+    "url": "git+https://github.com/rexxars/registry-auth-token.git"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
## Summary

Updates the public package repository metadata from the SSH GitHub URL to the equivalent public HTTPS GitHub URL.

## Why

`registry-auth-token` is a public npm package, but `package.json` currently advertises the repository as `git+ssh://git@github.com/rexxars/registry-auth-token.git`. Using the HTTPS form lets npm consumers and metadata tooling resolve the public source repository without requiring GitHub SSH configuration.

No runtime code, dependency, lockfile, package version, `bugs`, or `homepage` fields are changed.

## Validation

- Verified `package.json` parses and keeps the expected `bugs` and `homepage` values
- `npm pack --dry-run --ignore-scripts --json .`
- `npm test` (31 passing, then `standard`)
- `git diff --check`